### PR TITLE
Add the framework 'Mother'

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Mother"]
+	path = Mother
+	url = https://github.com/TruckersInSpace/Mother.git

--- a/bishop/build.gradle
+++ b/bishop/build.gradle
@@ -11,4 +11,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
+	compile project(':Mother:mother')
 }

--- a/bishop/src/main/AndroidManifest.xml
+++ b/bishop/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="uk.ac.uea.nostromo.bishop" android:versionCode="@string/version_code" android:versionName="@string/version_name">
+	<uses-sdk android:minSdkVersion="19" />
     <application />
 </manifest>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':bishop'
+include ':bishop', ':Mother:mother'


### PR DESCRIPTION
Import the project 'Mother' as a development framework, and make the
approriate changes to Bishop's build scripts to include this source.

'Mother' is a framework that interacts with the system on which our app
is running, and performs the actual work we require.

This commit also bumps the minimum required Android SDK version to '19'.